### PR TITLE
ARQ-625 Including test case containing EJB-JAR without descriptor.

### DIFF
--- a/was-remote-8/src/test/java/org/jboss/arquillian/container/was/remote_8/WebsphereIntegrationClientTestCase.java
+++ b/was-remote-8/src/test/java/org/jboss/arquillian/container/was/remote_8/WebsphereIntegrationClientTestCase.java
@@ -39,7 +39,6 @@ import org.junit.runner.RunWith;
  * @version $Revision: $
  */
 @RunWith(Arquillian.class)
-@Ignore
 public class WebsphereIntegrationClientTestCase
 {
    @Deployment


### PR DESCRIPTION
This was verified with WAS V8.0.0.5; will not work in WAS V8.0.0.[13]
