### PR TITLE
Fix dependencies on EJB3.1 API

### DIFF
--- a/was-remote-7/pom.xml
+++ b/was-remote-7/pom.xml
@@ -23,7 +23,6 @@
 
     <properties>
         <was_home>${env.WAS7_HOME}</was_home>
-        <version.ejb_api>3.1.0</version.ejb_api>
     </properties>
 
     <profiles>
@@ -121,9 +120,9 @@
         </dependency>
 
         <dependency>
-            <groupId>org.jboss.ejb3</groupId>
-            <artifactId>jboss-ejb3-api</artifactId>
-            <version>${version.ejb_api}</version>
+            <groupId>org.jboss.spec.javax.ejb</groupId>
+            <artifactId>jboss-ejb-api_3.1_spec</artifactId>
+            <version>1.0.2.Final</version>
             <scope>test</scope>
         </dependency>
 

--- a/was-remote-8/pom.xml
+++ b/was-remote-8/pom.xml
@@ -23,7 +23,6 @@
 
     <properties>
         <was_home>${env.WAS8_HOME}</was_home>
-        <version.ejb_api>3.1.0</version.ejb_api>
     </properties>
 
     <profiles>
@@ -124,9 +123,9 @@
         </dependency>
 
         <dependency>
-            <groupId>org.jboss.ejb3</groupId>
-            <artifactId>jboss-ejb3-api</artifactId>
-            <version>${version.ejb_api}</version>
+            <groupId>org.jboss.spec.javax.ejb</groupId>
+            <artifactId>jboss-ejb-api_3.1_spec</artifactId>
+            <version>1.0.2.Final</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
The WAS 7 & WAS 8 remote container adapters depend on org.jboss.ejb3:jboss-ejb3-api that I cannot find neither in the official Maven repository nor in repository.jboss.org.
But I can build and use the WAS 8 adapter if I replace that dependency with org.jboss.spec.javax.ejb:jboss-ejb-api_3.1_spec.
