### PR TITLE
J2EE 1.4 Deployment Descriptor Backwards Compatibility

### DIFF
--- a/was-remote-8.5/src/main/java/org/jboss/arquillian/container/was/remote_8_5/JavaEENamespaceContext.java
+++ b/was-remote-8.5/src/main/java/org/jboss/arquillian/container/was/remote_8_5/JavaEENamespaceContext.java
@@ -26,6 +26,7 @@ public class JavaEENamespaceContext implements NamespaceContext {
 	public String getNamespaceURI(String prefix) {
         if (prefix == null) throw new NullPointerException("Null prefix");
         else if ("javaee".equals(prefix)) return "http://java.sun.com/xml/ns/javaee";
+		  else if ("j2ee".equals(prefix)) return "http://java.sun.com/xml/ns/j2ee"; //J2EE 1.4 XML Schemas for backwards compatibility
         else if ("xml".equals(prefix)) return XMLConstants.XML_NS_URI;
         return XMLConstants.NULL_NS_URI;
 	}

--- a/was-remote-8.5/src/main/java/org/jboss/arquillian/container/was/remote_8_5/JavaEENamespaceContext.java
+++ b/was-remote-8.5/src/main/java/org/jboss/arquillian/container/was/remote_8_5/JavaEENamespaceContext.java
@@ -26,7 +26,7 @@ public class JavaEENamespaceContext implements NamespaceContext {
 	public String getNamespaceURI(String prefix) {
         if (prefix == null) throw new NullPointerException("Null prefix");
         else if ("javaee".equals(prefix)) return "http://java.sun.com/xml/ns/javaee";
-		  else if ("j2ee".equals(prefix)) return "http://java.sun.com/xml/ns/j2ee"; //J2EE 1.4 XML Schemas for backwards compatibility
+        else if ("j2ee".equals(prefix)) return "http://java.sun.com/xml/ns/j2ee"; //J2EE 1.4 XML Schemas for backwards compatibility
         else if ("xml".equals(prefix)) return XMLConstants.XML_NS_URI;
         return XMLConstants.NULL_NS_URI;
 	}

--- a/was-remote-8.5/src/main/java/org/jboss/arquillian/container/was/remote_8_5/WebSphereRemoteContainer.java
+++ b/was-remote-8.5/src/main/java/org/jboss/arquillian/container/was/remote_8_5/WebSphereRemoteContainer.java
@@ -392,7 +392,17 @@ public class WebSphereRemoteContainer implements DeployableContainer<WebSphereRe
          xpath.setNamespaceContext(new JavaEENamespaceContext());
          NodeList webModules = (NodeList) xpath.evaluate("/javaee:application/javaee:module/javaee:web", 
              new InputSource(new StringReader(applicationDD)), XPathConstants.NODESET);
-         
+
+         if (webModules.getLength() == 0){ //search J2EE 1.4 XML Schemas for backwards compatibility
+            webModules = (NodeList) xpath.evaluate("/j2ee:application/j2ee:module/j2ee:web",
+                    new InputSource(new StringReader(applicationDD)), XPathConstants.NODESET);
+         }
+
+         if (webModules.getLength() == 0){ //search no-namespace for DTD-based descriptor for backwards compatibility
+            webModules = (NodeList) xpath.evaluate("/application/module/web",
+                    new InputSource(new StringReader(applicationDD)), XPathConstants.NODESET);
+         }
+
          for (int i=0; i < webModules.getLength(); i++) {
             Node webModule = webModules.item(i);
             
@@ -422,7 +432,17 @@ public class WebSphereRemoteContainer implements DeployableContainer<WebSphereRe
             xpath.setNamespaceContext(new JavaEENamespaceContext());
             NodeList servletMappings = (NodeList) xpath.evaluate("/javaee:web-app/javaee:servlet-mapping",
                 new InputSource(new StringReader(webmoduleDD)), XPathConstants.NODESET);
-            
+
+            if (servletMappings.getLength() == 0) { //search J2EE 1.4 XML Schemas for backwards compatibility
+               servletMappings = (NodeList) xpath.evaluate("/j2ee:web-app/j2ee:servlet-mapping",
+                       new InputSource(new StringReader(webmoduleDD)), XPathConstants.NODESET);
+            }
+
+            if (servletMappings.getLength() == 0) { //search no-namespace for DTD-based descriptor for backwards compatibility
+               servletMappings = (NodeList) xpath.evaluate("/web-app/servlet-mapping",
+                       new InputSource(new StringReader(webmoduleDD)), XPathConstants.NODESET);
+            }
+
             for (int j=0; j < servletMappings.getLength(); j++) {
                Node servletMapping = servletMappings.item(j);
                NodeList servletMappingChildNodes = servletMapping.getChildNodes();


### PR DESCRIPTION
I had some issues deploying J2EE 1.4 project with the following DDs:

1)

< application id="Application_ID" version="1.4" xmlns="http://java.sun.com/xml/ns/j2ee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee http://java.sun.com/xml/ns/j2ee/application_1_4.xsd">
 (...)

2) 

<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE web-app PUBLIC "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN" "http://java.sun.com/dtd/web-app_2_3.dtd">

(...)

As I had to introduce fix for this, dont want these efforts to be lost.
Both DDs were tested.