### PR TITLE
Externalization of wlpHome

### DIFF
--- a/wlp-managed-8.5/pom.xml
+++ b/wlp-managed-8.5/pom.xml
@@ -40,6 +40,7 @@
 					</execution>
 				</executions>
 				<configuration>
+					<skip>${skipTests}</skip>
 					<serverName>defaultServer</serverName>
 					<install>
 						<licenseCode>L-MCAO-9SYMVC</licenseCode>

--- a/wlp-managed-8.5/src/main/java/org/jboss/arquillian/container/was/wlp_managed_8_5/WLPManagedContainerConfiguration.java
+++ b/wlp-managed-8.5/src/main/java/org/jboss/arquillian/container/was/wlp_managed_8_5/WLPManagedContainerConfiguration.java
@@ -30,7 +30,7 @@ import org.jboss.arquillian.container.spi.client.container.ContainerConfiguratio
 public class WLPManagedContainerConfiguration implements
       ContainerConfiguration {
    
-   private String wlpHome;
+   private String wlpHome = System.getenv("ARQUILLIAN_WLP_HOME");
    private String serverName = "defaultServer";
    private int httpPort = 0;
    private int serverStartTimeout = 30;
@@ -56,7 +56,7 @@ public class WLPManagedContainerConfiguration implements
             throw new ConfigurationException("wlpHome provided is not valid: " + wlpHome);
       } else {
          // If wlpHome is null, throw exception
-         throw new ConfigurationException("wlpHome is required for initialization");
+         throw new ConfigurationException("wlpHome or system env \"ARQUILLIAN_WLP_HOME\" is required for initialization");
       }
       
       // Validate serverName


### PR DESCRIPTION
Within our company we cannot hardcode the *wlpHome* path into the arquillian.xml file. This patch allows to set the path to WLP as a system environment variable called ARQUILLIAN_WLP_HOME. For me this seemed to be the easiest-to-configure solution.

Would be cool to find this or a similar approach in the final release of the wlp container :+1: 