### PR TITLE
ARQ-2115 Create Arquillian adapter for WebSphere 9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,7 @@
                 <module>was-embedded-8</module>
                 <module>was-remote-8</module>
                 <module>was-remote-8.5</module>
+                <module>was-remote-9</module>
                 <module>wlp-managed-8.5</module>
                 <module>wlp-remote-8.5</module>
             </modules>

--- a/was-remote-9/pom.xml
+++ b/was-remote-9/pom.xml
@@ -1,0 +1,169 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <!-- Parent -->
+    <parent>
+        <groupId>org.jboss.arquillian.container</groupId>
+        <artifactId>arquillian-parent-was</artifactId>
+        <version>1.0.0.Final-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <!-- Model Version -->
+    <modelVersion>4.0.0</modelVersion>
+
+    <!-- Artifact Configuration -->
+    <artifactId>arquillian-was-remote-9</artifactId>
+    <name>Arquillian Container WebSphere AS Remote 9.0</name>
+    <description>WebSphere AS 9.0 Remote Container integration for the Arquillian Project</description>
+
+
+    <!-- Properties -->
+
+    <properties>
+        <was_home>${env.WAS9_HOME}</was_home>
+        <version.jboss-spec-ejb3.1>1.0.2.Final</version.jboss-spec-ejb3.1>
+        <skipTests>true</skipTests>
+    </properties>
+
+    <profiles>
+        <profile>
+            <id>build-server</id>
+            <properties>
+                <was_home>${WAS9_HOME}</was_home>
+            </properties>
+        </profile>
+
+        <profile>
+            <id>ws-admin-jython27</id>
+            <properties>
+                <!-- In WebSphere 9, wsadmin is using jython27 by default. Jython21 is still supported and to use jython21,
+                     'com.ibm.ws.admin.client.forJython21_9.0.jar' should be used. Moreover, the new wsadmin jar has additional
+                     libraries which are not used by Arquillian (such as Python JSR 223 implementation) and might cause issues
+                     when deploying and running tests. If this happens, simply override this property with jython21 jar. -->
+                <ws_admin_client_jar_name>com.ibm.ws.admin.client_9.0.jar</ws_admin_client_jar_name>
+            </properties>
+            <activation>
+                <property>
+                    <name>!ws_admin_client_jar_name</name>
+                </property>
+            </activation>
+        </profile>
+    </profiles>
+
+
+    <!-- Build -->
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <skip>${skipTests}</skip>
+                    <systemProperties>
+                        <property>
+                            <name>java.util.logging.config.file</name>
+                            <value>${basedir}/src/test/resources/logging.properties</value>
+                        </property>
+                    </systemProperties>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <!-- Dependencies -->
+    <dependencies>
+
+        <!-- org.jboss.arquillian -->
+        <dependency>
+            <groupId>org.jboss.arquillian.container</groupId>
+            <artifactId>arquillian-container-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.container</groupId>
+            <artifactId>arquillian-container-test-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.protocol</groupId>
+            <artifactId>arquillian-protocol-servlet</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.testenricher</groupId>
+            <artifactId>arquillian-testenricher-cdi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.testenricher</groupId>
+            <artifactId>arquillian-testenricher-ejb</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.testenricher</groupId>
+            <artifactId>arquillian-testenricher-resource</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.testenricher</groupId>
+            <artifactId>arquillian-testenricher-initialcontext</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.shrinkwrap.descriptors</groupId>
+            <artifactId>shrinkwrap-descriptors-api-javaee</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.shrinkwrap.descriptors</groupId>
+            <artifactId>shrinkwrap-descriptors-impl-javaee</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <!-- com.ibm.websphere -->
+
+        <dependency>
+            <groupId>com.ibm.websphere</groupId>
+            <artifactId>was-public</artifactId>
+            <version>9.0</version>
+            <scope>system</scope>
+            <systemPath>${was_home}/dev/was_public.jar</systemPath>
+        </dependency>
+
+        <!-- Testing -->
+
+        <dependency>
+            <groupId>org.jboss.arquillian.junit</groupId>
+            <artifactId>arquillian-junit-container</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.spec.javax.ejb</groupId>
+            <artifactId>jboss-ejb-api_3.1_spec</artifactId>
+            <version>${version.jboss-spec-ejb3.1}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- com.ibm.websphere -->
+
+        <dependency>
+            <groupId>com.ibm.websphere</groupId>
+            <artifactId>ws-admin-client</artifactId>
+            <version>9.0</version>
+            <scope>system</scope>
+            <systemPath>${was_home}/runtimes/${ws_admin_client_jar_name}</systemPath>
+        </dependency>
+
+        <dependency>
+            <groupId>com.ibm.websphere</groupId>
+            <artifactId>jgss-provider</artifactId>
+            <version>9.0</version>
+            <scope>system</scope>
+            <systemPath>${was_home}/java/8.0/jre/lib/ibmjgssprovider.jar</systemPath>
+        </dependency>
+
+    </dependencies>
+</project>

--- a/was-remote-9/src/main/java/org/jboss/arquillian/container/was/remote_9/DeploymentNotificationListener.java
+++ b/was-remote-9/src/main/java/org/jboss/arquillian/container/was/remote_9/DeploymentNotificationListener.java
@@ -1,0 +1,104 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2010-2011, Red Hat Middleware LLC, and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.container.was.remote_9;
+
+import java.util.Properties;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.management.Notification;
+import javax.management.NotificationFilterSupport;
+import javax.management.NotificationListener;
+import javax.management.ObjectName;
+
+import com.ibm.websphere.management.AdminClient;
+import com.ibm.websphere.management.application.AppNotification;
+
+public class DeploymentNotificationListener implements NotificationListener
+{
+   private static Logger log = Logger.getLogger(DeploymentNotificationListener.class.getName());
+   private AdminClient adminClient;
+   private NotificationFilterSupport filterSupport;
+   private ObjectName objectName;
+   private String eventTypeToCheck;
+   private boolean successful = true;
+   private String message = "";
+   private Properties notificationProps = new Properties();
+
+   public DeploymentNotificationListener(AdminClient adminClient, NotificationFilterSupport support, Object handBack, String eventTypeToCheck) 
+      throws Exception
+   {
+      super();
+      this.adminClient = adminClient;
+      this.filterSupport = support;
+      this.eventTypeToCheck = eventTypeToCheck;
+      this.objectName = (ObjectName) adminClient.queryNames(new ObjectName("WebSphere:type=AppManagement,*"), null)
+            .iterator().next();
+      adminClient.addNotificationListener(objectName, this, filterSupport, handBack);
+   }
+
+   public void handleNotification(Notification notification, Object handback)
+   {
+      AppNotification appNotification = (AppNotification) notification.getUserData();
+      if (log.isLoggable(Level.FINEST)) {
+         log.finest("handleNotification message: " + appNotification.message);
+         log.finest("handleNotification taskName: " + appNotification.taskName);
+         log.finest("handleNotification taskStatus: " + appNotification.taskStatus);
+         log.finest("handleNotification eventProps: " + appNotification.props);
+      }
+      message = message += "\n" + appNotification.message;
+      if (
+            appNotification.taskName.equals(eventTypeToCheck) && 
+            (appNotification.taskStatus.equals(AppNotification.STATUS_COMPLETED) || 
+                  appNotification.taskStatus.equals(AppNotification.STATUS_FAILED)))
+      {
+         try
+         {
+            adminClient.removeNotificationListener(objectName, this);
+            if (appNotification.taskStatus.equals(AppNotification.STATUS_FAILED))
+            {
+               successful = false;
+            } else {
+               notificationProps = appNotification.props;
+            }
+               
+            synchronized (this)
+            {
+               notifyAll();
+            }
+         }
+         catch (Exception e)
+         {
+         }
+      }
+   }
+
+   public String getMessage()
+   {
+      return message;
+   }
+   
+   public Properties getNotificationProps()
+   {
+      return notificationProps;
+   }
+   
+   public boolean isSuccessful()
+   {
+      return successful;
+   }
+}

--- a/was-remote-9/src/main/java/org/jboss/arquillian/container/was/remote_9/JavaEENamespaceContext.java
+++ b/was-remote-9/src/main/java/org/jboss/arquillian/container/was/remote_9/JavaEENamespaceContext.java
@@ -1,0 +1,44 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat Middleware LLC, and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.container.was.remote_9;
+
+import java.util.Iterator;
+
+import javax.xml.XMLConstants;
+import javax.xml.namespace.NamespaceContext;
+
+public class JavaEENamespaceContext implements NamespaceContext {
+
+	public String getNamespaceURI(String prefix) {
+        if (prefix == null) throw new NullPointerException("Null prefix");
+        else if ("javaee".equals(prefix)) return "http://java.sun.com/xml/ns/javaee";
+        else if ("j2ee".equals(prefix)) return "http://java.sun.com/xml/ns/j2ee"; //J2EE 1.4 XML Schemas for backwards compatibility
+        else if ("xml".equals(prefix)) return XMLConstants.XML_NS_URI;
+        return XMLConstants.NULL_NS_URI;
+	}
+
+	public String getPrefix(String uri) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	public Iterator getPrefixes(String uri) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+}

--- a/was-remote-9/src/main/java/org/jboss/arquillian/container/was/remote_9/WebSphereExtension.java
+++ b/was-remote-9/src/main/java/org/jboss/arquillian/container/was/remote_9/WebSphereExtension.java
@@ -1,0 +1,37 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.container.was.remote_9;
+
+import org.jboss.arquillian.container.spi.client.container.DeployableContainer;
+import org.jboss.arquillian.core.spi.LoadableExtension;
+
+/**
+ * WebSphereExtension
+ *
+ * @author <a href="mailto:gerhard.poul@gmail.com">Gerhard Poul</a>
+ * @version $Revision: $
+ */
+public class WebSphereExtension implements LoadableExtension
+{
+   @Override
+   public void register(ExtensionBuilder builder)
+   {
+      builder.service(DeployableContainer.class, WebSphereRemoteContainer.class);
+   }
+
+}

--- a/was-remote-9/src/main/java/org/jboss/arquillian/container/was/remote_9/WebSphereRemoteContainer.java
+++ b/was-remote-9/src/main/java/org/jboss/arquillian/container/was/remote_9/WebSphereRemoteContainer.java
@@ -1,0 +1,648 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2009-2011, Red Hat Middleware LLC, and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.container.was.remote_9;
+
+import java.io.File;
+import java.io.StringReader;
+import java.lang.IllegalStateException;
+import java.util.Arrays;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.Locale;
+import java.util.Properties;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.management.Attribute;
+import javax.management.AttributeList;
+import javax.management.InstanceNotFoundException;
+import javax.management.MalformedObjectNameException;
+import javax.management.NotificationFilterSupport;
+import javax.management.ObjectName;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathFactory;
+
+import org.jboss.arquillian.container.spi.client.container.DeployableContainer;
+import org.jboss.arquillian.container.spi.client.container.DeploymentException;
+import org.jboss.arquillian.container.spi.client.container.LifecycleException;
+import org.jboss.arquillian.container.spi.client.protocol.ProtocolDescription;
+import org.jboss.arquillian.container.spi.client.protocol.metadata.HTTPContext;
+import org.jboss.arquillian.container.spi.client.protocol.metadata.ProtocolMetaData;
+import org.jboss.arquillian.container.spi.client.protocol.metadata.Servlet;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.descriptor.api.Descriptor;
+import org.jboss.shrinkwrap.descriptor.api.Descriptors;
+import org.jboss.shrinkwrap.descriptor.api.application6.ApplicationDescriptor;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+
+import com.ibm.websphere.management.AdminClient;
+import com.ibm.websphere.management.AdminClientFactory;
+import com.ibm.websphere.management.application.AppConstants;
+import com.ibm.websphere.management.application.AppManagement;
+import com.ibm.websphere.management.application.AppManagementProxy;
+import com.ibm.websphere.management.application.AppNotification;
+import com.ibm.websphere.management.application.client.AppDeploymentController;
+import com.ibm.websphere.management.configservice.ConfigServiceHelper;
+import com.ibm.websphere.management.configservice.ConfigServiceProxy;
+import com.ibm.websphere.management.exception.ConfigServiceException;
+import com.ibm.websphere.management.exception.ConnectorException;
+
+/**
+ * WebSphereRemoteContainer
+ *
+ * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
+ * @author <a href="mailto:gerhard.poul@gmail.com">Gerhard Poul</a>
+ * @version $Revision: $
+ */
+public class WebSphereRemoteContainer implements DeployableContainer<WebSphereRemoteContainerConfiguration>
+{
+   //-------------------------------------------------------------------------------------||
+   // Instance Members -------------------------------------------------------------------||
+   //-------------------------------------------------------------------------------------||
+   
+   private static final String className = WebSphereRemoteContainer.class.getName();
+   
+   private static Logger log = Logger.getLogger(className);
+   
+   private WebSphereRemoteContainerConfiguration containerConfiguration;
+
+   private AdminClient adminClient;
+
+   //-------------------------------------------------------------------------------------||
+   // Required Implementations - DeployableContainer -------------------------------------||
+   //-------------------------------------------------------------------------------------||
+
+   /* (non-Javadoc)
+    * @see org.jboss.arquillian.spi.DeployableContainer#setup(org.jboss.arquillian.spi.Context, org.jboss.arquillian.spi.Configuration)
+    */
+   public void setup(WebSphereRemoteContainerConfiguration configuration)
+   {
+      if (log.isLoggable(Level.FINER)) {
+            log.entering(className, "setup");
+      }
+	   
+      this.containerConfiguration = configuration;
+	   
+      if (log.isLoggable(Level.FINER)) {
+         log.exiting(className, "setup");
+      }
+   }
+
+   /* (non-Javadoc)
+    * @see org.jboss.arquillian.spi.DeployableContainer#start(org.jboss.arquillian.spi.Context)
+    */
+   public void start() throws LifecycleException
+   {
+      if (log.isLoggable(Level.FINER)) {
+         log.entering(className, "start");
+      }
+      
+      Properties wasServerProps = new Properties();
+      wasServerProps.setProperty(AdminClient.CONNECTOR_HOST, containerConfiguration.getRemoteServerAddress());
+      wasServerProps.setProperty(AdminClient.CONNECTOR_PORT, String.valueOf(containerConfiguration.getRemoteServerSoapPort()));
+      wasServerProps.setProperty(AdminClient.CONNECTOR_TYPE, AdminClient.CONNECTOR_TYPE_SOAP);
+      wasServerProps.setProperty(AdminClient.USERNAME, containerConfiguration.getUsername());
+      
+      if (containerConfiguration.getSecurityEnabled())
+      {
+         wasServerProps.setProperty(AdminClient.CONNECTOR_SECURITY_ENABLED, "true");
+         wasServerProps.setProperty(AdminClient.PASSWORD, containerConfiguration.getPassword());
+         wasServerProps.setProperty(AdminClient.CACHE_DISABLED, "false"); 
+         wasServerProps.setProperty("javax.net.ssl.trustStore", containerConfiguration.getSslTrustStore());
+         wasServerProps.setProperty("javax.net.ssl.keyStore", containerConfiguration.getSslKeyStore());
+         wasServerProps.setProperty("javax.net.ssl.trustStorePassword", containerConfiguration.getSslTrustStorePassword());
+         wasServerProps.setProperty("javax.net.ssl.keyStorePassword", containerConfiguration.getSslKeyStorePassword());
+         if (containerConfiguration.getSslTrustStoreType() != null)
+            wasServerProps.setProperty("javax.net.ssl.trustStoreType", containerConfiguration.getSslTrustStoreType());
+         if (containerConfiguration.getSslKeyStoreType() != null)
+            wasServerProps.setProperty("javax.net.ssl.keyStoreType", containerConfiguration.getSslKeyStoreType());
+      } else {
+         wasServerProps.setProperty(AdminClient.CONNECTOR_SECURITY_ENABLED, "false");
+      }
+      
+      try
+      {
+         adminClient = AdminClientFactory.createAdminClient(wasServerProps);
+         
+         ObjectName serverMBean = adminClient.getServerMBean();
+         String processType = serverMBean.getKeyProperty("processType");
+         
+         log.fine("CanonicalKeyPropertyListString: " + serverMBean.getCanonicalKeyPropertyListString());
+         
+         if (processType.equals("DeploymentManager")
+               || processType.equals("NodeAgent")
+               || processType.equals("ManagedProcess"))
+            throw new IllegalStateException("Connecting to a " + processType + " is not supported.");
+      } 
+      catch (Exception e) 
+      {
+         throw new LifecycleException("Could not create AdminClient: " + e.getMessage(), e);
+      }
+      
+      if (log.isLoggable(Level.FINER)) {
+         log.exiting(className, "start");
+      }
+   }
+
+   /* (non-Javadoc)
+    * @see org.jboss.arquillian.spi.DeployableContainer#deploy(org.jboss.arquillian.spi.Context, org.jboss.shrinkwrap.api.Archive)
+    */
+   public ProtocolMetaData deploy(final Archive<?> archive) throws DeploymentException
+   {
+      if (log.isLoggable(Level.FINER)) {
+         log.entering(className, "deploy");
+         
+         log.finer("Archive provided to deploy method: " + archive.toString(true));
+      }
+      
+      File exportedArchiveLocation = null;
+      ProtocolMetaData metaData = null;
+      EnterpriseArchive deploymentArchive = null;
+      
+      // Create an EAR file from the provided Archive that can be processed by AppDeploymentController
+      if (WebArchive.class.isInstance(archive)) {
+         // Packaging a single WAR file into an EAR
+         String earName = archive.getName().substring(0, archive.getName().lastIndexOf("."));
+         log.fine("Creating an EnterpriseArchive " + earName + ".ear from provided WebArchive " + archive.getName() + ".");
+
+         // Create ShrinkWrap EnterpriseArchive and add the WAR file as a module
+         deploymentArchive = ShrinkWrap.create(EnterpriseArchive.class, earName + ".ear")
+            .addAsModule(archive);
+
+         // Generate the application.xml DD and add it to the EAR
+         ApplicationDescriptor appDescriptor = Descriptors.create(ApplicationDescriptor.class);
+         appDescriptor.createModule().getOrCreateWeb().webUri(archive.getName()).contextRoot(earName);
+         deploymentArchive.setApplicationXML(
+               new StringAsset(appDescriptor.exportAsString()));
+      } else if (EnterpriseArchive.class.isInstance(archive)){
+         // Use the provided EnterpriseArchive as-is
+         deploymentArchive = (EnterpriseArchive) archive;
+      } else {
+         throw new DeploymentException("Unsupported archive type has been provided for deployment: " + archive.getClass().getName());
+      }
+
+      String appName = createDeploymentName(deploymentArchive.getName());
+      String appExtension = createDeploymentExtension(deploymentArchive.getName());
+      
+      try
+      {
+         exportedArchiveLocation = File.createTempFile(appName, appExtension);
+         deploymentArchive.as(ZipExporter.class).exportTo(exportedArchiveLocation, true);
+         
+         Hashtable<Object, Object> prefs = new Hashtable<Object, Object>();
+         
+         prefs.put(AppConstants.APPDEPL_LOCALE, Locale.getDefault());
+         prefs.put(AppConstants.APPDEPL_CLASSLOADINGMODE, containerConfiguration.getDeploymentClassLoadingMode());
+         prefs.put(AppConstants.APPDEPL_CLASSLOADERPOLICY, containerConfiguration.getDeploymentClassLoaderPolicy());
+
+         log.fine(String.format("Deploying with classloading mode %s",
+                 containerConfiguration.getDeploymentClassLoadingMode()));
+         log.fine(String.format("Deploying with classloader policy %s",
+                 containerConfiguration.getDeploymentClassLoaderPolicy()));
+
+         Properties props = new Properties();
+         prefs.put (AppConstants.APPDEPL_DFLTBNDG, props);
+         props.put (AppConstants.APPDEPL_DFLTBNDG_VHOST, "default_host");
+
+         // Prepare application for deployment to WebSphere Application Server
+         AppDeploymentController controller = AppDeploymentController
+         	.readArchive(exportedArchiveLocation.getAbsolutePath(), prefs);
+
+         String[] validationResult = controller.validate();
+         if (validationResult != null && validationResult.length > 0) {
+            throw new DeploymentException("Unable to complete all task data for deployment preparation. Reason: " + Arrays.toString(validationResult));
+         }
+         
+         controller.saveAndClose();
+         
+         if (log.isLoggable(Level.FINER)) {
+            // Log the contents of the saved archive from AppDeploymentController
+            Archive<JavaArchive> savedArchive = ShrinkWrap.createFromZipFile(JavaArchive.class, exportedArchiveLocation);
+            log.finer("Archive prepared for deployment: " + savedArchive.toString(true));            
+         }
+         
+         Hashtable<Object, Object> module2Server = new Hashtable<Object, Object>();
+         ObjectName serverMBean = adminClient.getServerMBean();
+         
+         String targetServer = "WebSphere:cell=" + serverMBean.getKeyProperty("cell")
+                              + ",node=" + serverMBean.getKeyProperty("node")
+                              + ",server=" + serverMBean.getKeyProperty("process");
+         
+         log.info("Target server for deployment is " + targetServer);
+   
+         module2Server.put("*",targetServer);
+         
+         prefs.put(AppConstants.APPDEPL_MODULE_TO_SERVER, module2Server);
+         prefs.put(AppConstants.APPDEPL_ARCHIVE_UPLOAD, containerConfiguration.isArchiveUploadEnabled());
+         
+         AppManagement appManagementProxy = AppManagementProxy.getJMXProxyForClient(adminClient);
+         
+         NotificationFilterSupport filterSupport = new NotificationFilterSupport();
+         filterSupport.enableType(AppConstants.NotificationType);
+         DeploymentNotificationListener listener = new DeploymentNotificationListener(
+                  adminClient, 
+                  filterSupport, 
+                  "Install " + appName,
+                  AppNotification.INSTALL);
+         
+         appManagementProxy.installApplication(
+               exportedArchiveLocation.getAbsolutePath(),
+               appName, 
+               prefs,
+               null);
+         
+         synchronized(listener) 
+         {
+            listener.wait();
+         }
+
+         if(!listener.isSuccessful())
+            throw new IllegalStateException("Application not sucessfully deployed: " + listener.getMessage());            
+
+         DeploymentNotificationListener distributionListener = null;
+         int checkCount = 0;
+         while (checkDistributionStatus(distributionListener) != AppNotification.DISTRIBUTION_DONE
+               && ++checkCount < 300)
+         {
+            Thread.sleep(1000);
+            
+            distributionListener = new DeploymentNotificationListener(
+                  adminClient,
+                  filterSupport,
+                  null,
+                  AppNotification.DISTRIBUTION_STATUS_NODE);
+            
+            synchronized(distributionListener)
+            {
+               appManagementProxy.getDistributionStatus(appName, new Hashtable<Object, Object>(), null);
+               distributionListener.wait();
+            }
+         }
+
+         if (checkCount < 300)
+         {
+            String targetsStarted = appManagementProxy.startApplication(appName, null, null);
+            log.info("Application was started on the following targets: " + targetsStarted);
+            if (targetsStarted == null)
+               throw new IllegalStateException("Start of the application was not successful. WAS JVM logs should contain the detailed error message.");
+         } else {
+            throw new IllegalStateException("Distribution of application did not succeed to all nodes.");
+         }
+         
+         metaData = discoverProtocolMetaDataFromConfiguration(adminClient, 
+               serverMBean.getKeyProperty("node"),
+               serverMBean.getKeyProperty("process"),
+               appName);
+      } 
+      catch (Exception e) 
+      {
+         throw new DeploymentException("Could not deploy application", e);
+      }
+      finally
+      {
+         if(exportedArchiveLocation != null) 
+         {  
+            exportedArchiveLocation.delete();
+         }
+      }
+      
+      if (log.isLoggable(Level.FINER)) {
+         log.exiting(className, "deploy");
+      }
+      
+      return metaData;
+   }
+   
+   @SuppressWarnings("rawtypes")
+   private ProtocolMetaData discoverProtocolMetaDataFromConfiguration(AdminClient adminClient, String targetNode, String targetProcess, String appName) throws InstanceNotFoundException, ConnectorException, ConfigServiceException {
+      ProtocolMetaData metaData = new ProtocolMetaData();
+      String remoteServerAddress = null;
+      int remoteServerHttpPort = 0;
+      
+      ConfigServiceProxy configServiceProxy = new ConfigServiceProxy(adminClient);
+      
+      ObjectName nodeObjectName = ConfigServiceHelper.createObjectName(null, "Node");
+      ObjectName[] nodeObjectNames = configServiceProxy.queryConfigObjects(null, null, nodeObjectName, null);
+      ObjectName targetNodeObjectName = null;
+      
+      for (ObjectName node : nodeObjectNames) {
+         String nodeName = (String) configServiceProxy.getAttribute(null, node, "name");
+         if (nodeName.equals(targetNode)) {
+            targetNodeObjectName = node;
+            remoteServerAddress = (String) configServiceProxy.getAttribute(null, targetNodeObjectName, 
+                  "hostName");
+         }
+      }
+      
+      if (remoteServerAddress == null || targetNodeObjectName == null)
+         throw new InstanceNotFoundException("Target node " + targetNode + " was not found.");
+      
+      ObjectName serverEntries = ConfigServiceHelper.createObjectName(null, "ServerEntry");
+      ObjectName[] serverEntryObjectNames = configServiceProxy.queryConfigObjects(null, 
+            targetNodeObjectName, serverEntries, null);
+      
+      for (ObjectName serverEntry : serverEntryObjectNames) {
+         String serverName = (String) configServiceProxy.getAttribute(null, serverEntry, "serverName");
+         if (serverName.equals(targetProcess)) {
+            List specialEndpoints = (List) configServiceProxy.getAttribute(null, serverEntry, 
+                  "specialEndpoints");
+            remoteServerHttpPort = getEndpointPort(specialEndpoints, "WC_defaulthost");
+         }
+      }
+      
+      log.fine("Generating HTTPContext: " + remoteServerAddress + ", " + remoteServerHttpPort);
+      HTTPContext httpContext = new HTTPContext(remoteServerAddress, remoteServerHttpPort);
+      
+      try {
+         Set applicationObjectNameSet = adminClient.queryNames(
+               new ObjectName("WebSphere:type=J2EEApplication,name=" + appName + ",*"), null);
+         if (applicationObjectNameSet.isEmpty())
+            throw new InstanceNotFoundException("Unable to find application in JMX: " + appName);
+         
+         ObjectName applicationObjectName = (ObjectName)applicationObjectNameSet.iterator().next();
+         String applicationDD = (String)adminClient.getAttribute(applicationObjectName, "deploymentDescriptor");
+
+         log.fine("applicationDD: " + applicationDD);
+         
+         XPath xpath = XPathFactory.newInstance().newXPath();
+         xpath.setNamespaceContext(new JavaEENamespaceContext());
+         NodeList webModules = (NodeList) xpath.evaluate("/javaee:application/javaee:module/javaee:web", 
+             new InputSource(new StringReader(applicationDD)), XPathConstants.NODESET);
+
+         if (webModules.getLength() == 0){ //search J2EE 1.4 XML Schemas for backwards compatibility
+            webModules = (NodeList) xpath.evaluate("/j2ee:application/j2ee:module/j2ee:web",
+                    new InputSource(new StringReader(applicationDD)), XPathConstants.NODESET);
+         }
+
+         if (webModules.getLength() == 0){ //search no-namespace for DTD-based descriptor for backwards compatibility
+            webModules = (NodeList) xpath.evaluate("/application/module/web",
+                    new InputSource(new StringReader(applicationDD)), XPathConstants.NODESET);
+         }
+
+         for (int i=0; i < webModules.getLength(); i++) {
+            Node webModule = webModules.item(i);
+            
+            String weburi="", contextroot="";
+            NodeList webModuleChildNodes = webModule.getChildNodes();
+            for (int j=0; j < webModuleChildNodes.getLength(); j++) {
+               Node webModuleChild = webModuleChildNodes.item(j);
+               if (webModuleChild.getNodeName().equals("web-uri"))
+                  weburi = webModuleChild.getTextContent();
+               if (webModuleChild.getNodeName().equals("context-root"))
+                  contextroot = webModuleChild.getTextContent();
+            }
+            
+            // Now look up the currentModule and figure out its servlets
+            
+            Set webmoduleObjectNameSet = adminClient.queryNames(
+                  new ObjectName("WebSphere:type=WebModule,name=" + weburi + ",*"), null);
+            if (webmoduleObjectNameSet.isEmpty())
+               throw new IllegalStateException("Unable to find web module in JMX: " + weburi);
+            
+            ObjectName webmoduleObjectName = (ObjectName)webmoduleObjectNameSet.iterator().next();
+            String webmoduleDD = (String)adminClient.getAttribute(webmoduleObjectName, "deploymentDescriptor");
+            
+            log.fine("webmoduleDD: " + webmoduleDD);
+   
+            xpath = XPathFactory.newInstance().newXPath();
+            xpath.setNamespaceContext(new JavaEENamespaceContext());
+            NodeList servletMappings = (NodeList) xpath.evaluate("/javaee:web-app/javaee:servlet-mapping",
+                new InputSource(new StringReader(webmoduleDD)), XPathConstants.NODESET);
+
+            if (servletMappings.getLength() == 0) { //search J2EE 1.4 XML Schemas for backwards compatibility
+               servletMappings = (NodeList) xpath.evaluate("/j2ee:web-app/j2ee:servlet-mapping",
+                       new InputSource(new StringReader(webmoduleDD)), XPathConstants.NODESET);
+            }
+
+            if (servletMappings.getLength() == 0) { //search no-namespace for DTD-based descriptor for backwards compatibility
+               servletMappings = (NodeList) xpath.evaluate("/web-app/servlet-mapping",
+                       new InputSource(new StringReader(webmoduleDD)), XPathConstants.NODESET);
+            }
+
+            for (int j=0; j < servletMappings.getLength(); j++) {
+               Node servletMapping = servletMappings.item(j);
+               NodeList servletMappingChildNodes = servletMapping.getChildNodes();
+               String servletName = null;
+               for (int k=0; k < servletMappingChildNodes.getLength(); k++) {
+                  Node childNode = servletMappingChildNodes.item(k);
+                  if (childNode.getNodeName().equals("url-pattern"))
+                     servletName = childNode.getTextContent().replaceFirst("/", "");
+               }
+               if (servletName != null) {
+                  log.fine("Adding servlet to context: " + servletName + ", " + contextroot);
+                  httpContext.add(new Servlet(servletName, contextroot));
+               } else {
+                  log.warning("Unable to find servlet-name in web-module " + weburi + " deployment descriptor");
+               }
+            }
+         }
+      } catch (Exception e) {
+         log.log(Level.SEVERE, "Error while processing the deployment descriptor", e);
+      }
+      
+      metaData.addContext(httpContext);
+
+      return metaData;
+   }
+
+   @SuppressWarnings("rawtypes")
+   private int getEndpointPort(List specialEndpoints, String endPointIdentifier) {
+      for (Object specialEndpoint : specialEndpoints) {
+         AttributeList specialEndpointAttributeList = (AttributeList)specialEndpoint;
+         String endPointName = (String)getAttributeByName(specialEndpointAttributeList, "endPointName");
+         if (endPointName.equals(endPointIdentifier)) {
+            AttributeList endpointAttributeList = 
+               (AttributeList)getAttributeByName(specialEndpointAttributeList, "endPoint");
+            return (Integer)getAttributeByName(endpointAttributeList, "port");
+         }
+      }
+      return 0;
+   }
+   
+   private Object getAttributeByName(AttributeList attrList, String name) {
+      for (Object attrObject : attrList) {
+         Attribute attr = (Attribute)attrObject;
+         if (attr.getName().equals(name))
+            return attr.getValue();
+      }
+      return null;
+   }
+
+   /*
+    * Checks the listener and figures out the aggregate distribution status of all nodes
+    */
+   private String checkDistributionStatus(DeploymentNotificationListener listener) throws MalformedObjectNameException, NullPointerException, IllegalStateException {
+      String distributionState = AppNotification.DISTRIBUTION_UNKNOWN;
+      if (listener != null)
+      {
+        String compositeStatus = listener.getNotificationProps()
+           .getProperty(AppNotification.DISTRIBUTION_STATUS_COMPOSITE);
+        if (compositeStatus != null)
+        {
+           log.finer("compositeStatus: " + compositeStatus);
+           String[] serverStati = compositeStatus.split("\\+");
+           int countTrue = 0, countFalse = 0, countUnknown = 0;
+           for (String serverStatus : serverStati)
+           {
+              ObjectName objectName = new ObjectName(serverStatus);
+              distributionState = objectName.getKeyProperty("distribution");
+              log.finer("distributionState: " + distributionState);
+              if (distributionState.equals("true"))
+                 countTrue++;
+              if (distributionState.equals("false"))
+                 countFalse++;
+              if (distributionState.equals("unknown"))
+                 countUnknown++;
+           }
+           if (countUnknown > 0)
+           {
+              distributionState = AppNotification.DISTRIBUTION_UNKNOWN;
+           } else if (countFalse > 0) {
+              distributionState = AppNotification.DISTRIBUTION_NOT_DONE;
+           } else if (countTrue > 0) {
+              distributionState = AppNotification.DISTRIBUTION_DONE;
+           } else {
+              throw new IllegalStateException("Reported distribution status is invalid.");
+           }
+        }
+      }
+      return distributionState;
+   }
+
+   /* (non-Javadoc)
+    * @see org.jboss.arquillian.spi.DeployableContainer#undeploy(org.jboss.arquillian.spi.Context, org.jboss.shrinkwrap.api.Archive)
+    */
+   public void undeploy(final Archive<?> archive) throws DeploymentException
+   {
+      if (log.isLoggable(Level.FINER)) {
+         log.entering(className, "undeploy");
+      }
+      
+      String appName = createDeploymentName(archive.getName());
+      
+      try
+      {
+//         Session configSession = new Session(containerConfiguraiton.getUsername(), false);
+//         ConfigServiceProxy configProxy = new ConfigServiceProxy(adminClient);
+
+         Hashtable<Object, Object> prefs = new Hashtable<Object, Object>();
+
+         NotificationFilterSupport filterSupport = new NotificationFilterSupport();
+         filterSupport.enableType(AppConstants.NotificationType);
+         DeploymentNotificationListener listener = new DeploymentNotificationListener(
+                  adminClient, 
+                  filterSupport, 
+                  "Uninstall " + appName,
+                  AppNotification.UNINSTALL);
+         
+         AppManagement appManagementProxy = AppManagementProxy.getJMXProxyForClient(adminClient);
+         
+         appManagementProxy.uninstallApplication(
+               appName, 
+               prefs,
+               null);
+//               configSession.getSessionId());
+         
+         synchronized(listener) 
+         {
+            listener.wait();
+         }
+         if(listener.isSuccessful())
+         {
+            //configProxy.save(configSession, true);
+         }
+         else
+         {
+            throw new IllegalStateException("Application not sucessfully undeployed: " + listener.getMessage());
+            //configProxy.discard(configSession);
+         }
+      } 
+      catch (Exception e) 
+      {
+         throw new DeploymentException("Could not undeploy application", e);
+      }
+      
+      if (log.isLoggable(Level.FINER)) {
+         log.exiting(className, "undeploy");
+      }
+   }
+
+   /* (non-Javadoc)
+    * @see org.jboss.arquillian.spi.DeployableContainer#stop(org.jboss.arquillian.spi.Context)
+    */
+   public void stop() throws LifecycleException
+   {
+      if (log.isLoggable(Level.FINER)) {
+         log.entering(className, "stop");
+      }
+      
+      if (log.isLoggable(Level.FINER)) {
+         log.exiting(className, "stop");
+      }
+   }
+
+   //-------------------------------------------------------------------------------------||
+   // Internal Helper Methods ------------------------------------------------------------||
+   //-------------------------------------------------------------------------------------||
+   
+   private String createDeploymentName(String archiveName) 
+   {
+      return archiveName.substring(0, archiveName.lastIndexOf("."));
+   }
+
+   private String createDeploymentExtension(String archiveName) 
+   {
+      return archiveName.substring(archiveName.lastIndexOf("."));
+   }
+
+	public Class<WebSphereRemoteContainerConfiguration> getConfigurationClass() {
+		// TODO Auto-generated method stub
+		return WebSphereRemoteContainerConfiguration.class;
+	}
+	
+	public ProtocolDescription getDefaultProtocol() {
+      if (log.isLoggable(Level.FINER)) {
+         log.entering(className, "getDefaultProtocol");
+      }
+      
+      if (log.isLoggable(Level.FINER)) {
+         log.exiting(className, "getDefaultProtocol");
+      }
+      
+		return new ProtocolDescription("Servlet 3.0");
+	}
+	
+	public void deploy(Descriptor descriptor) throws DeploymentException {
+		// TODO Auto-generated method stub
+		
+	}
+	
+	public void undeploy(Descriptor descriptor) throws DeploymentException {
+		// TODO Auto-generated method stub
+		
+	}
+}

--- a/was-remote-9/src/main/java/org/jboss/arquillian/container/was/remote_9/WebSphereRemoteContainerConfiguration.java
+++ b/was-remote-9/src/main/java/org/jboss/arquillian/container/was/remote_9/WebSphereRemoteContainerConfiguration.java
@@ -1,0 +1,228 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2009-2011, Red Hat Middleware LLC, and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.container.was.remote_9;
+
+import com.ibm.websphere.management.application.AppConstants;
+import org.jboss.arquillian.container.spi.ConfigurationException;
+import org.jboss.arquillian.container.spi.client.container.ContainerConfiguration;
+
+/**
+ * WebSphereRemoteConfiguraiton
+ *
+ * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class WebSphereRemoteContainerConfiguration implements ContainerConfiguration
+{
+   private String remoteServerAddress = "localhost";
+   private Integer remoteServerSoapPort = 8880;
+   
+   private boolean securityEnabled = false;
+
+   private String username = "admin";
+   private String password = "admin";
+   
+   private String sslTrustStore = "";
+   private String sslKeyStore = "";
+   private String sslTrustStorePassword = "WebAS";
+   private String sslKeyStorePassword = "WebAS";
+   private String sslTrustStoreType = null;
+   private String sslKeyStoreType = null;
+
+   /** Enables or disables the upload of the deployable archive to the server
+    * (AppConstants.APPDEPL_ARCHIVE_UPLOAD). Can be false for local servers and speeds
+    * deployment for large archives. */
+   private boolean archiveUploadEnabled = true;
+
+   /**
+    * Specifies the classloading mode for deployed application ({@link AppConstants#APPDEPL_CLASSLOADINGMODE}):
+    * <ul>
+    *   <li>parent-first ({@link AppConstants#APPDEPL_CLASSLOADINGMODE_PARENTFIRST}) - the default,</li>
+    *   <li>parent-last ({@link AppConstants#APPDEPL_CLASSLOADINGMODE_PARENTLAST}).</li>
+    * </ul>
+    */
+   private String deploymentClassLoadingMode = AppConstants.APPDEPL_CLASSLOADINGMODE_PARENTFIRST;
+
+   /**
+    * Specifies the classloader policy for deployed application ({@link AppConstants#APPDEPL_CLASSLOADERPOLICY}):
+    * <ul>
+    *   <li>multiple classloaders for each WAR within the EAR
+    *       ({@link AppConstants#APPDEPL_CLASSLOADERPOLICY_MULTIPLE}) - the default,</li>
+    *   <li>single classloader for the whole EAR ({@link AppConstants#APPDEPL_CLASSLOADERPOLICY_SINGLE}).</li>
+    * </ul>
+    */
+   private String deploymentClassLoaderPolicy = AppConstants.APPDEPL_CLASSLOADERPOLICY_MULTIPLE;
+
+   /**
+    * @return the remoteServerAddress
+    */
+   public String getRemoteServerAddress()
+   {
+      return remoteServerAddress;
+   }
+
+   /**
+    * @param remoteServerAddress the remoteServerAddress to set
+    */
+   public void setRemoteServerAddress(String remoteServerAddress)
+   {
+      this.remoteServerAddress = remoteServerAddress;
+   }
+
+   /**
+    * @return the remoteServerSoapPort
+    */
+   public Integer getRemoteServerSoapPort()
+   {
+      return remoteServerSoapPort;
+   }
+
+   /**
+    * @param remoteServerSoapPort the remoteServerSoapPort to set
+    */
+   public void setRemoteServerSoapPort(Integer remoteServerSoapPort)
+   {
+      this.remoteServerSoapPort = remoteServerSoapPort;
+   }
+
+   public void setSecurityEnabled(boolean securityEnabled) {
+      this.securityEnabled = securityEnabled;
+   }
+
+   public boolean getSecurityEnabled() {
+      return securityEnabled;
+   }
+
+   /**
+    * @return the username
+    */
+   public String getUsername()
+   {
+      return username;
+   }
+   
+   /**
+    * @param username the username to set
+    */
+   public void setUsername(String username)
+   {
+      this.username = username;
+   }
+
+	public void setPassword(String password) {
+      this.password = password;
+   }
+
+   public String getPassword() {
+      return password;
+   }
+
+   public void setSslTrustStore(String sslTrustStore) {
+      this.sslTrustStore = sslTrustStore;
+   }
+
+   public String getSslTrustStore() {
+      return sslTrustStore;
+   }
+
+   public void setSslKeyStore(String sslKeyStore) {
+      this.sslKeyStore = sslKeyStore;
+   }
+
+   public String getSslKeyStore() {
+      return sslKeyStore;
+   }
+
+   public void setSslTrustStorePassword(String sslTrustStorePassword) {
+      this.sslTrustStorePassword = sslTrustStorePassword;
+   }
+
+   public String getSslTrustStorePassword() {
+      return sslTrustStorePassword;
+   }
+
+   public void setSslKeyStorePassword(String sslKeyStorePassword) {
+      this.sslKeyStorePassword = sslKeyStorePassword;
+   }
+
+   public String getSslKeyStorePassword() {
+      return sslKeyStorePassword;
+   }
+
+   public void setSslTrustStoreType(String sslTrustStoreType) {
+       this.sslTrustStoreType = sslTrustStoreType;
+   }
+
+   public String getSslTrustStoreType() {
+       return this.sslTrustStoreType;
+   }
+
+   public void setSslKeyStoreType(String sslKeyStoreType) {
+       this.sslKeyStoreType = sslKeyStoreType;
+   }
+
+   public String getSslKeyStoreType() {
+       return this.sslKeyStoreType;
+   }
+
+   @Override
+   public void validate() throws ConfigurationException {
+       if (!AppConstants.APPDEPL_CLASSLOADINGMODE_PARENTFIRST.equals(deploymentClassLoadingMode)
+               && !AppConstants.APPDEPL_CLASSLOADINGMODE_PARENTLAST.equals(deploymentClassLoadingMode)) {
+
+           throw new ConfigurationException(String.format("Illegal value %s for deploymentClassLoadingMode. "
+                                                          + "Possible values: %s, %s",
+                                                          deploymentClassLoadingMode,
+                                                          AppConstants.APPDEPL_CLASSLOADINGMODE_PARENTFIRST,
+                                                          AppConstants.APPDEPL_CLASSLOADINGMODE_PARENTLAST));
+       }
+
+       if (!AppConstants.APPDEPL_CLASSLOADERPOLICY_MULTIPLE.equals(deploymentClassLoaderPolicy)
+               && !AppConstants.APPDEPL_CLASSLOADERPOLICY_SINGLE.equals(deploymentClassLoaderPolicy)) {
+
+           throw new ConfigurationException(String.format("Illegal value %s for deploymentClassLoaderPolicy. "
+                                                          + "Possible values: %s, %s",
+                                                          deploymentClassLoaderPolicy,
+                                                          AppConstants.APPDEPL_CLASSLOADERPOLICY_MULTIPLE,
+                                                          AppConstants.APPDEPL_CLASSLOADERPOLICY_SINGLE));
+       }
+   }
+
+   public void setArchiveUploadEnabled(boolean enabled) {
+      this.archiveUploadEnabled = enabled;
+   }
+
+   public boolean isArchiveUploadEnabled() {
+      return this.archiveUploadEnabled;
+   }
+
+   public String getDeploymentClassLoadingMode() {
+       return this.deploymentClassLoadingMode;
+   }
+
+   public void setDeploymentClassLoadingMode(final String deploymentClassLoadingMode) {
+       this.deploymentClassLoadingMode = deploymentClassLoadingMode;
+   }
+
+   public String getDeploymentClassLoaderPolicy() {
+       return this.deploymentClassLoaderPolicy;
+   }
+
+   public void setDeploymentClassLoaderPolicy(final String deploymentClassLoaderPolicy) {
+       this.deploymentClassLoaderPolicy = deploymentClassLoaderPolicy;
+   }
+}

--- a/was-remote-9/src/main/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
+++ b/was-remote-9/src/main/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
@@ -1,0 +1,1 @@
+org.jboss.arquillian.container.was.remote_9.WebSphereExtension

--- a/was-remote-9/src/test/java/org/jboss/arquillian/container/was/remote_9/Greeter.java
+++ b/was-remote-9/src/test/java/org/jboss/arquillian/container/was/remote_9/Greeter.java
@@ -1,0 +1,29 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013, Red Hat Middleware LLC, and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.container.was.remote_9;
+
+/**
+ * Greeter
+ * 
+ * @author <a href="mailto:gerhard.poul@gmail.com">Gerhard Poul</a>
+ */
+public class Greeter {
+    public String createGreeting(String name) {
+        return "Hello, " + name + "!";
+    }
+}
+

--- a/was-remote-9/src/test/java/org/jboss/arquillian/container/was/remote_9/WebSphereClassInjectionTestCase.java
+++ b/was-remote-9/src/test/java/org/jboss/arquillian/container/was/remote_9/WebSphereClassInjectionTestCase.java
@@ -1,0 +1,55 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013, Red Hat Middleware LLC, and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.container.was.remote_9;
+
+import javax.inject.Inject;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * WebSphereClassInjectionTestCase
+ *
+ * @author <a href="mailto:gerhard.poul@gmail.com">Gerhard Poul</a>
+ */
+@RunWith(Arquillian.class)
+public class WebSphereClassInjectionTestCase
+{
+   @Deployment
+   public static JavaArchive createDeployment() {
+       JavaArchive jar = ShrinkWrap.create(JavaArchive.class)
+           .addClass(Greeter.class)
+           .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+       return jar;
+   }
+   
+   @Inject
+   Greeter greeter;
+
+   @Test
+   public void should_create_greeting() {
+       Assert.assertEquals("Hello, Earthling!",
+           greeter.createGreeting("Earthling"));
+   }
+}
+

--- a/was-remote-9/src/test/java/org/jboss/arquillian/container/was/remote_9/WebSphereResourceInjectionTestCase.java
+++ b/was-remote-9/src/test/java/org/jboss/arquillian/container/was/remote_9/WebSphereResourceInjectionTestCase.java
@@ -1,0 +1,49 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat Middleware LLC, and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.container.was.remote_9;
+
+import javax.annotation.Resource;
+import javax.transaction.UserTransaction;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * WebSphereResourceInjectionTestCase
+ *
+ * @author <a href="mailto:gerhard.poul@gmail.com">Gerhard Poul</a>
+ */
+@RunWith(Arquillian.class)
+public class WebSphereResourceInjectionTestCase
+{
+   @Deployment
+   public static WebArchive createDeployment() {
+      return ShrinkWrap.create(WebArchive.class, "ResourceInjectionTestCase.war");
+   }
+   
+   @Resource(mappedName = "java:comp/UserTransaction") UserTransaction userTransaction;
+   
+   @Test
+   public void shouldBeAbleToInjectResource() throws Exception {
+      Assert.assertNotNull(userTransaction);
+   }
+}

--- a/was-remote-9/src/test/java/org/jboss/arquillian/container/was/remote_9/WebsphereIntegrationClientTestCase.java
+++ b/was-remote-9/src/test/java/org/jboss/arquillian/container/was/remote_9/WebsphereIntegrationClientTestCase.java
@@ -1,0 +1,80 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2009-2011, Red Hat Middleware LLC, and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.container.was.remote_9;
+
+import javax.ejb.EJB;
+
+import junit.framework.Assert;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.was.remote_9.ejb.MyEjb;
+import org.jboss.arquillian.container.was.remote_9.ejb.MyEjbLocal;
+import org.jboss.arquillian.container.was.remote_9.ejb.MyEjbRemote;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * WebsphereIntegrationClientTestCase
+ *
+ * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+@RunWith(Arquillian.class)
+public class WebsphereIntegrationClientTestCase
+{
+   @Deployment
+   public static EnterpriseArchive createDeployment() 
+   {
+      return ShrinkWrap.create(EnterpriseArchive.class, "IntegrationClientTestCase.ear")
+                  .addAsModule(ShrinkWrap.create(JavaArchive.class, "test.jar")
+                                    .addClass(MyEjb.class)
+                                    .addClass(MyEjbLocal.class)
+                                    .addClass(MyEjbRemote.class)
+                                    .addClass(WebsphereIntegrationClientTestCase.class));
+   }
+   
+   @EJB
+   private MyEjbLocal localInstanceVariable;
+   
+   @EJB
+   private MyEjbRemote remoteInstanceVariable;
+   
+   @Test
+   public void shouldBeAbleToInjectLocalEJBAsInstanceVariable() throws Exception 
+   {
+      Assert.assertNotNull(
+            "Verify that the local Bean has been injected",
+            localInstanceVariable);
+      
+      Assert.assertEquals("aslak", localInstanceVariable.getName());
+   }
+   
+   @Test
+   public void shouldBeAbleToInjectRemoteEJBAsInstanceVariable() throws Exception
+   {
+      Assert.assertNotNull(
+            "Verify that the remote Bean has been injected",
+            remoteInstanceVariable);
+      
+      Assert.assertEquals("aslak", remoteInstanceVariable.getName());
+   }
+
+}

--- a/was-remote-9/src/test/java/org/jboss/arquillian/container/was/remote_9/ejb/MyEjb.java
+++ b/was-remote-9/src/test/java/org/jboss/arquillian/container/was/remote_9/ejb/MyEjb.java
@@ -1,0 +1,34 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2009, Red Hat Middleware LLC, and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.container.was.remote_9.ejb;
+
+import javax.ejb.Stateless;
+
+/**
+ * MyEjb
+ *
+ * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+@Stateless
+public class MyEjb implements MyEjbLocal, MyEjbRemote
+{
+   public String getName() 
+   {
+      return "aslak";
+   }
+}

--- a/was-remote-9/src/test/java/org/jboss/arquillian/container/was/remote_9/ejb/MyEjbLocal.java
+++ b/was-remote-9/src/test/java/org/jboss/arquillian/container/was/remote_9/ejb/MyEjbLocal.java
@@ -1,0 +1,31 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2009, Red Hat Middleware LLC, and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.container.was.remote_9.ejb;
+
+import javax.ejb.Local;
+
+/**
+ * MyEjbLocal
+ *
+ * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+@Local
+public interface MyEjbLocal
+{
+   public String getName();
+}

--- a/was-remote-9/src/test/java/org/jboss/arquillian/container/was/remote_9/ejb/MyEjbRemote.java
+++ b/was-remote-9/src/test/java/org/jboss/arquillian/container/was/remote_9/ejb/MyEjbRemote.java
@@ -1,0 +1,31 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2009, 2011, Red Hat Middleware LLC, and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.container.was.remote_9.ejb;
+
+import javax.ejb.Remote;
+
+/**
+ * MyEjbRemote
+ *
+ * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+@Remote
+public interface MyEjbRemote
+{
+   public String getName();
+}

--- a/was-remote-9/src/test/resources/arquillian.xml
+++ b/was-remote-9/src/test/resources/arquillian.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<arquillian xmlns="http://www.jboss.org/arquillian-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.jboss.org/arquillian-1.0 http://jboss.org/schema/arquillian/arquillian-1.0.xsd">
+
+	<engine>
+		<property name="deploymentExportPath">target/</property>
+	</engine>
+
+	<container qualifier="websphere" default="true">
+		<configuration>
+			<property name="remoteServerAddress">localhost</property>
+			<property name="remoteServerSoapPort">8880</property>
+			<property name="securityEnabled">false</property>
+			<property name="username">admin</property>
+			<!-- <property name="password">admin</property>
+ 			<property name="sslTrustStore">C:/IBM/WebSphere/AppServer/profiles/AppSrv01/etc/DummyClientTrustFile.jks</property>
+			<property name="sslTrustStorePassword">WebAS</property> -->
+		</configuration>
+	</container>
+</arquillian>

--- a/was-remote-9/src/test/resources/logging.properties
+++ b/was-remote-9/src/test/resources/logging.properties
@@ -1,0 +1,25 @@
+#
+# JBoss, Home of Professional Open Source
+# Copyright 2011, Red Hat Middleware LLC, and individual contributors
+# by the @authors tag. See the copyright.txt in the distribution for a
+# full listing of individual contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
+# Setup a standard ConsoleHandler in mode FINEST
+handlers= java.util.logging.ConsoleHandler
+java.util.logging.ConsoleHandler.level = FINEST
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+# Configure WAS Container classes to FINEST; everything else to INFO
+.level= INFO
+org.jboss.arquillian.container.was.level = FINEST


### PR DESCRIPTION
#### Short description of what this resolves:
Hi, guys,

my name is Marian Macik and I work at Red Hat as QE Engineer on [jBPM](https://github.com/kiegroup/jbpm) project. This PR introduces Arquillian container adapter for WebSphere 9. We have been using it at Red Hat in our QE automation for about two months without any issues. It is copied from adapter for WebSphere 8.5 (as WebSphere 8.5 was copied from WebSphere 8). There were only some minor changes when it comes to system paths pointing at WebSphere dependencies (jgss-provider and ws-admin-client).

However, since WebSphere 9, wsadmin is using jython27 by default. Jython21 is still supported and to use jython21, 'com.ibm.ws.admin.client.forJython21_9.0.jar' should be used. Moreover, the new wsadmin jar has additional libraries which are not used by Arquillian (such as Python JSR 223 implementation) and might cause issues when deploying and running tests. If this happens, simply override this property with jython21 jar:

`-Dws_admin_client_jar_name=com.ibm.ws.admin.client.forJython21_9.0.jar`

I added this property because the new jython27 wsadmin implementation was causing issues since it loaded unwanted classes on the classpath. Of course, by default the new jython27 wsadmin is used, override is optional.

I have also run the enclosed tests with my own arquillian.xml and they have passed.

Here is the community issue I have created for it:
[ARQ-2115](https://issues.jboss.org/browse/ARQ-2115)

Thanks,

Marian
