### PR TITLE
Support for multi-app verification before test app deployment

### DIFF
--- a/wlp-managed-8.5/src/main/java/org/jboss/arquillian/container/was/wlp_managed_8_5/WLPManagedContainer.java
+++ b/wlp-managed-8.5/src/main/java/org/jboss/arquillian/container/was/wlp_managed_8_5/WLPManagedContainer.java
@@ -409,7 +409,7 @@ public class WLPManagedContainer implements DeployableContainer<WLPManagedContai
 	private void waitForVerifyApps() throws DeploymentException {
 		String verifyApps = containerConfiguration.getVerifyApps();
 		
-		if(verifyApps.length() > 0) {
+		if(verifyApps != null && verifyApps.length() > 0) {
 			String[] verifyAppList = verifyApps.split(",");
 			int totalTimeout = containerConfiguration.getVerifyAppDeployTimeout() * verifyAppList.length;
 

--- a/wlp-managed-8.5/src/main/java/org/jboss/arquillian/container/was/wlp_managed_8_5/WLPManagedContainer.java
+++ b/wlp-managed-8.5/src/main/java/org/jboss/arquillian/container/was/wlp_managed_8_5/WLPManagedContainer.java
@@ -417,7 +417,9 @@ public class WLPManagedContainer implements DeployableContainer<WLPManagedContai
 			for (int i = 0; i < verifyAppList.length; i++) {
 				String appToVerify = verifyAppList[i];
 				appToVerify = appToVerify.trim();
-				verifyAppList[i] = appToVerify;
+				if(appToVerify.length() > 0) {
+					verifyAppList[i] = appToVerify;
+				}
 			}
 
 			waitForApplicationTargetState(verifyAppList, true, totalTimeout);

--- a/wlp-managed-8.5/src/main/java/org/jboss/arquillian/container/was/wlp_managed_8_5/WLPManagedContainerConfiguration.java
+++ b/wlp-managed-8.5/src/main/java/org/jboss/arquillian/container/was/wlp_managed_8_5/WLPManagedContainerConfiguration.java
@@ -47,7 +47,7 @@ public class WLPManagedContainerConfiguration implements
    private boolean allowConnectingToRunningServer = Boolean.parseBoolean(
          System.getProperty("org.jboss.arquillian.container.was.wlp_managed_8_5.allowConnectingToRunningServer",  "false"));
    private boolean outputToConsole = true;
-   private String verifyApps = "";
+   private String verifyApps = null;
    private int verifyAppDeployTimeout = appDeployTimeout;
 
    @Override

--- a/wlp-managed-8.5/src/main/java/org/jboss/arquillian/container/was/wlp_managed_8_5/WLPManagedContainerConfiguration.java
+++ b/wlp-managed-8.5/src/main/java/org/jboss/arquillian/container/was/wlp_managed_8_5/WLPManagedContainerConfiguration.java
@@ -33,6 +33,7 @@ public class WLPManagedContainerConfiguration implements
    private String wlpHome;
    private String serverName = "defaultServer";
    private int httpPort = 0;
+   
    private int serverStartTimeout = 30;
    private int appDeployTimeout = 20;
    private int appUndeployTimeout = 2;
@@ -42,11 +43,11 @@ public class WLPManagedContainerConfiguration implements
    private boolean addLocalConnector;
    private String securityConfiguration;
    private boolean failSafeUndeployment = false;
-
    private boolean allowConnectingToRunningServer = Boolean.parseBoolean(
          System.getProperty("org.jboss.arquillian.container.was.wlp_managed_8_5.allowConnectingToRunningServer",  "false"));
-
    private boolean outputToConsole = true;
+   private String verifyApps = "";
+   private int verifyAppDeployTimeout = appDeployTimeout;
 
    @Override
    public void validate() throws ConfigurationException {
@@ -80,7 +81,7 @@ public class WLPManagedContainerConfiguration implements
       if (!deployType.equalsIgnoreCase("xml") && !deployType.equalsIgnoreCase("dropins"))
          throw new ConfigurationException("deployType provided is not valid: " + deployType + ".  deployType should be xml or dropins.");
 
-      //Validate sharedLib
+      // Validate sharedLib
       if (sharedLib != null) {
          if (!sharedLib.isEmpty()) {
             if (!deployType.equalsIgnoreCase("xml"))
@@ -213,6 +214,22 @@ public class WLPManagedContainerConfiguration implements
 
    public void setFailSafeUndeployment(boolean failSafeUndeployment) {
 	   this.failSafeUndeployment = failSafeUndeployment;
+   }
+   
+   public String getVerifyApps() {
+	   return verifyApps;
+   }
+   
+   public void setVerifyApps(String verifyApps) {
+	   this.verifyApps = verifyApps;
+   }
+   
+   public int getVerifyAppDeployTimeout() {
+	   return verifyAppDeployTimeout;
+   }
+   
+   public void setVerifyAppDeployTimeout(int verifyAppDeployTimeout) {
+	   this.verifyAppDeployTimeout = verifyAppDeployTimeout;
    }
 
 }


### PR DESCRIPTION
#### Short description of what this resolves:
When Arquillian tests depend on other applications on the same server, there is no guarantee in the current implementation that those applications will be ready before the tests run. This PR adds support for an optional `verifyApps` parameter that allows users to specify a comma-separated list of application names that tests depend on. The code ensures that these applications will be started before the deployment of the test application takes place. 

#### Changes proposed in this pull request:

- Addition of `verifyApps` and `verifyAppDeployTimeout` parameters
- Refactoring of `waitForApplicationTargetState` to support multiple deployments
- Small changes for code cleanup