### PR TITLE
added cdi-api dependency in liberty-managed pom

### DIFF
--- a/liberty-managed/pom.xml
+++ b/liberty-managed/pom.xml
@@ -134,6 +134,12 @@
       <artifactId>arquillian-testenricher-initialcontext</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>javax.enterprise</groupId>
+      <artifactId>cdi-api</artifactId>
+      <version>2.0</version>
+    </dependency>
+
     <!-- Java EE Spec APIs -->
 
     <dependency>


### PR DESCRIPTION
Signed-off-by: Gordon Hutchison <Gordon.Hutchison@gmail.com>

I suspect that this PR can be closed as Gerhard has the issue covered.
I just wanted to verify the diff and that I have tested with this change.

The discussion is in https://github.com/arquillian/arquillian-container-was/pull/33#issuecomment-376995527

Feel free to merge or close whichever is most convenient. 
