### PR TITLE
Fixes for deploying multiple apps and finding servlets

### DIFF
--- a/liberty-managed/pom.xml
+++ b/liberty-managed/pom.xml
@@ -40,6 +40,20 @@
               <goal>create-server</goal>
             </goals>
           </execution>
+          <execution>
+            <id>create-server-management</id>
+            <!-- Plugin execution only succeeds here in the correct order because
+                 execution id of the test is not 'default-test'.
+                 Because Maven. See MNG-5799 and MNG-5987 -->
+            <phase>test</phase>
+            <configuration>
+              <serverName>managementServer</serverName>
+              <configFile>src/test/resources/server-with-management.xml</configFile>
+            </configuration>
+            <goals>
+              <goal>create-server</goal>
+            </goals>
+          </execution>
         </executions>
         <configuration>
           <skip>${skipTests}</skip>
@@ -79,6 +93,9 @@
               <systemPropertyVariables>
                 <arquillian.launch>wlp-dropins-deployment</arquillian.launch>
               </systemPropertyVariables>
+              <excludes>
+                <exclude>**/needsmanagementmbeans/**</exclude>
+              </excludes>
             </configuration>
           </execution>
           <execution>
@@ -93,8 +110,26 @@
               <systemPropertyVariables>
                 <arquillian.launch>wlp-xml-deployment</arquillian.launch>
               </systemPropertyVariables>
+              <excludes>
+                <exclude>**/needsmanagementmbeans/**</exclude>
+              </excludes>
             </configuration>
           </execution>
+          <execution>
+            <id>wlp-xml-management-deployment-test</id>
+            <phase>test</phase>
+            <goals>
+              <goal>test</goal>
+            </goals>
+            <configuration>
+              <skip>${skipTests}</skip>
+              <reportsDirectory>${project.build.directory}/surefire-reports/wlp-xml-management-deployment-test</reportsDirectory>
+              <systemPropertyVariables>
+                <arquillian.launch>wlp-xml-management-deployment</arquillian.launch>
+              </systemPropertyVariables>
+            </configuration>
+          </execution>
+          
         </executions>
       </plugin>
     </plugins>
@@ -132,6 +167,16 @@
     <dependency>
       <groupId>org.jboss.arquillian.testenricher</groupId>
       <artifactId>arquillian-testenricher-initialcontext</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.shrinkwrap.descriptors</groupId>
+      <artifactId>shrinkwrap-descriptors-api-javaee</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.shrinkwrap.descriptors</groupId>
+      <artifactId>shrinkwrap-descriptors-impl-javaee</artifactId>
+      <scope>test</scope>
     </dependency>
 
     <!-- Java EE Spec APIs -->

--- a/liberty-managed/src/main/java/org/jboss/arquillian/container/was/wlp_managed_8_5/WLPManagedContainer.java
+++ b/liberty-managed/src/main/java/org/jboss/arquillian/container/was/wlp_managed_8_5/WLPManagedContainer.java
@@ -614,7 +614,7 @@ public class WLPManagedContainer implements DeployableContainer<WLPManagedContai
             Document document = readServerXML();
 
             // Remove the archive from the server.xml file
-            removeApplication(document);
+            removeApplication(document, deployName);
 
             // Update server.xml on file system
             writeServerXML(document);
@@ -834,13 +834,13 @@ public class WLPManagedContainer implements DeployableContainer<WLPManagedContai
       root.appendChild(createApplication(doc, deployName, archiveName, type));
    }
 
-   private void removeApplication(Document doc)
+   private void removeApplication(Document doc, String deployName)
    {
       Node server = doc.getElementsByTagName("server").item(0);
       NodeList serverlist = server.getChildNodes();
       for (int i=0; serverlist.getLength() > i; i++) {
          Node node = serverlist.item(i);
-         if (node.getNodeName().equals("application")) {
+         if (node.getNodeName().equals("application") && node.getAttributes().getNamedItem("id").getNodeValue().equals(deployName)) {
             node.getParentNode().removeChild(node);
          }
       }

--- a/liberty-managed/src/test/java/org/jboss/arquillian/container/was/wlp_managed_8_5/needsmanagementmbeans/BarServlet.java
+++ b/liberty-managed/src/test/java/org/jboss/arquillian/container/was/wlp_managed_8_5/needsmanagementmbeans/BarServlet.java
@@ -1,0 +1,21 @@
+package org.jboss.arquillian.container.was.wlp_managed_8_5.needsmanagementmbeans;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@WebServlet("/bar")
+public class BarServlet extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        resp.getWriter().print("I am bar");
+    }
+
+}

--- a/liberty-managed/src/test/java/org/jboss/arquillian/container/was/wlp_managed_8_5/needsmanagementmbeans/BazServlet.java
+++ b/liberty-managed/src/test/java/org/jboss/arquillian/container/was/wlp_managed_8_5/needsmanagementmbeans/BazServlet.java
@@ -1,0 +1,20 @@
+package org.jboss.arquillian.container.was.wlp_managed_8_5.needsmanagementmbeans;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@WebServlet("/baz")
+public class BazServlet extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        resp.getWriter().print("I am baz");
+    }
+}

--- a/liberty-managed/src/test/java/org/jboss/arquillian/container/was/wlp_managed_8_5/needsmanagementmbeans/FooServlet.java
+++ b/liberty-managed/src/test/java/org/jboss/arquillian/container/was/wlp_managed_8_5/needsmanagementmbeans/FooServlet.java
@@ -1,0 +1,20 @@
+package org.jboss.arquillian.container.was.wlp_managed_8_5.needsmanagementmbeans;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@WebServlet("/foo")
+public class FooServlet extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        resp.getWriter().print("I am foo");
+    }
+}

--- a/liberty-managed/src/test/java/org/jboss/arquillian/container/was/wlp_managed_8_5/needsmanagementmbeans/WLPInjectServletContextTest.java
+++ b/liberty-managed/src/test/java/org/jboss/arquillian/container/was/wlp_managed_8_5/needsmanagementmbeans/WLPInjectServletContextTest.java
@@ -1,0 +1,123 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2010-2012, Red Hat Middleware LLC, and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.container.was.wlp_managed_8_5.needsmanagementmbeans;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.net.URL;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.descriptor.api.Descriptors;
+import org.jboss.shrinkwrap.descriptor.api.application7.ApplicationDescriptor;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class WLPInjectServletContextTest
+{
+    
+    private static final String DEPLOYMENT1 = "app1";
+    private static final String DEPLOYMENT2 = "app2";
+    
+    
+    @Deployment(testable = false, name = DEPLOYMENT1)
+    public static WebArchive app1() {
+        return ShrinkWrap.create(WebArchive.class)
+                .addClass(FooServlet.class);
+    }
+    
+    @Deployment(testable = false, name = DEPLOYMENT2)
+    public static EnterpriseArchive app2() {
+        EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class)
+                .addAsModule(ShrinkWrap.create(WebArchive.class, "test1.war")
+                             .addClass(BarServlet.class))
+                .addAsModule(ShrinkWrap.create(WebArchive.class, "test2.war")
+                             .addClass(BazServlet.class));
+        
+        ApplicationDescriptor appXml = Descriptors.create(ApplicationDescriptor.class)
+                                                     .version(ApplicationDescriptor.VERSION)
+                                                     .applicationName("testApp")
+                                                     .createModule().getOrCreateWeb().contextRoot("/test1").webUri("test1.war").up().up()
+                                                     .createModule().getOrCreateWeb().contextRoot("/test2").webUri("test2.war").up().up()
+                                                     ;
+        ear.setApplicationXML(new StringAsset(appXml.exportAsString()));
+        
+        return ear;
+    }
+    
+    @ArquillianResource(FooServlet.class)
+    @OperateOnDeployment(DEPLOYMENT1)
+    private URL fooContextRoot;
+    
+    @ArquillianResource(BarServlet.class)
+    @OperateOnDeployment(DEPLOYMENT2)
+    private URL barContextRoot;
+    
+    @ArquillianResource(BazServlet.class)
+    @OperateOnDeployment(DEPLOYMENT2)
+    private URL bazContextRoot;
+    
+    @Test
+    public void testFoo() throws Exception {
+        URL url = new URL(fooContextRoot, "foo");
+        String response = readAllAndClose(url.openStream());
+        assertEquals("I am foo", response);
+    }
+    
+    @Test
+    public void testBar() throws Exception {
+        URL url = new URL(barContextRoot, "bar");
+        String response = readAllAndClose(url.openStream());
+        assertEquals("I am bar", response);
+    }
+    
+    @Test
+    public void testBaz() throws Exception {
+        URL url = new URL(bazContextRoot, "baz");
+        String response = readAllAndClose(url.openStream());
+        assertEquals("I am baz", response);
+    }
+    
+    private String readAllAndClose(InputStream is) throws Exception 
+    {
+       ByteArrayOutputStream out = new ByteArrayOutputStream();
+       try
+       {
+          int read;
+          while( (read = is.read()) != -1)
+          {
+             out.write(read);
+          }
+       }
+       finally 
+       {
+          try { is.close(); } catch (Exception e) { }
+       }
+       return out.toString();
+    }
+
+}

--- a/liberty-managed/src/test/resources/arquillian.xml
+++ b/liberty-managed/src/test/resources/arquillian.xml
@@ -32,4 +32,16 @@
       <property name="appUndeployTimeout">10</property>
     </configuration>
   </container>
+  <container qualifier="wlp-xml-management-deployment">
+    <configuration>
+      <property name="wlpHome">${project.build.directory}/liberty/wlp/</property>
+      <property name="deployType">xml</property>
+      <property name="serverName">managementServer</property>
+
+      <!-- Adjust timeouts to work on Cloudbees CI server -->
+      <property name="appDeployTimeout">60</property>
+      <property name="appUndeployTimeout">10</property>
+    </configuration>
+  </container>
+  
 </arquillian>

--- a/liberty-managed/src/test/resources/server-with-management.xml
+++ b/liberty-managed/src/test/resources/server-with-management.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server description="new server">
+
+    <!-- Enable features -->
+    <featureManager>
+        <feature>jsp-2.3</feature>
+        <feature>localConnector-1.0</feature>
+        <feature>cdi-1.2</feature>
+        <feature>j2eeManagement-1.1</feature>
+    </featureManager>
+
+    <!-- To access this server from a remote client add a host attribute 
+        to the following element, e.g. host="*" -->
+    <httpEndpoint httpPort="9080" httpsPort="9443"
+        id="defaultHttpEndpoint" />
+
+    <applicationMonitor updateTrigger="mbean" />
+
+</server>


### PR DESCRIPTION
#### Short description of what this resolves:
1) When deploying apps by editing server.xml, undeploy will remove all apps, not just the one requested.

2) Tests that use `@ArquillianResource(MyServlet.class)` don't work.

#### Changes proposed in this pull request:
1) When undeploying apps deployed using the server.xml, only remove the requested app
  * Needed to pass tests like this: https://github.com/cdi-spec/cdi-tck/blob/2.0.4.Final/impl/src/main/java/org/jboss/cdi/tck/tests/context/application/destroy/ApplicationContextDestructionTest.java

2) If the j2eeManagement feature is enabled, use the J2EE management MBeans to determine which servlets are deployed into which web modules.
  * Needed to pass tests like this: https://github.com/cdi-spec/cdi-tck/blob/2.0.4.Final/impl/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/environment/jndi/InterceptorEnvironmentJNDITest.java
  * If the feature is not enabled, fall back to the old behaviour


**Fixes**: #
